### PR TITLE
Proposal: Add flag to scan string literals

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,11 +29,12 @@ Flags:
 		flag.PrintDefaults()
 	}
 	scanComments := flag.Bool("comments", false, "also scan comments")
+	scanStringLits := flag.Bool("string-literals", true, "also scan string literals")
 	flag.Parse()
 
 	var lines []string
 	for _, file := range listFiles(flag.Args()) {
-		lines = append(lines, scanFile(file, *scanComments)...)
+		lines = append(lines, scanFile(file, *scanComments, *scanStringLits)...)
 	}
 	if len(lines) > 0 {
 		log.Fatalln(strings.Join(lines, "\n"))
@@ -61,7 +62,7 @@ func listFiles(args []string) (files []string) {
 
 // scanFile scans file and returns formatted error strings for each line in
 // file that contains a homoglyph.
-func scanFile(file string, scanComments bool) (lines []string) {
+func scanFile(file string, scanComments bool, scanStringLits bool) (lines []string) {
 	src, err := ioutil.ReadFile(file)
 	if err != nil {
 		log.Fatal(err)
@@ -83,6 +84,9 @@ func scanFile(file string, scanComments bool) (lines []string) {
 		pos, tok, lit := s.Scan()
 		if tok == token.EOF {
 			return
+		}
+		if !scanStringLits && tok == token.STRING {
+			continue
 		}
 		for _, c := range lit {
 			if c >= utf8.RuneSelf && isHomoglyph(c) {


### PR DESCRIPTION
You can't run glypcheck on itself without this flag :P

There are many cases (user messages written in other languages, i18n, etc) where you wouldn't want to scan string literals. However, use this flag with caution — as mentioned in the README, import statements and URLs use string literals.

Also, what do you think about checking if the string literal is part of an import statement? I didn't bother to implement this as you should still use caution with URLs.

String literals are scanned by default.

I'll write tests after the PR #1 is merged, and if you think this flag is a good idea.